### PR TITLE
Fix arduino.h name to keep compatibility on Linux

### DIFF
--- a/src/sx1509_registers.h
+++ b/src/sx1509_registers.h
@@ -1,6 +1,6 @@
 #ifndef SX1509_REGS_H
 #define SX1509_REGS_H
-#include "arduino.h"
+#include "Arduino.h"
 
 /* 
 	sx1509_registers.h


### PR DESCRIPTION
Linux is case sensitive and the sketches that use `sx1509_registers.h` fail to compile so I switched the arduino.h include to capital case.
